### PR TITLE
PLATFORM-3098: Separate rule for helios metrics

### DIFF
--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -22,14 +22,6 @@ data:
       Measurement: access_logs
       RetentionPolicy: default
     Rules:
-      - Id: generic-internal
-    #    UrlRegexp: ^/info
-        FrontendRegexp: \.k8s\.wikia\.net
-        Sampling: 1.0
-      - Id: generic-external
-    #    UrlRegexp: ^/info
-        FrontendRegexp: services-k8s\.wikia-dev\.(us|pl)
-        Sampling: 1.0
       - Id: alerting-tester
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/alerting-tester
         SamplingRate: 1.0

--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -30,6 +30,9 @@ data:
     #    UrlRegexp: ^/info
         FrontendRegexp: services-k8s\.wikia-dev\.(us|pl)
         Sampling: 1.0
+      - Id: alerting-tester
+        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/alerting-tester
+        SamplingRate: 1.0
       - Id: whoami
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/whoami
         SamplingRate: 1.0

--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -30,8 +30,11 @@ data:
     #    UrlRegexp: ^/info
         FrontendRegexp: services-k8s\.wikia-dev\.(us|pl)
         Sampling: 1.0
-      - Id: services-all
-        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net
+      - Id: whoami
+        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/whoami
+        SamplingRate: 1.0
+      - Id: geoip
+        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/geoip
         SamplingRate: 1.0
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios

--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -33,3 +33,6 @@ data:
       - Id: services-all
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net
         SamplingRate: 1.0
+      - Id: helios
+        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
+        SamplingRate: 1.0


### PR DESCRIPTION
We cannot filter out helios metrics in `TraefikApdexTick`, as it doesn't allow to query based on frontend (and the path doesn't contain `helios` string). So I'm putting helios metrics in a separate rule and will use it for configuring Helios alerts.