### PR TITLE
SER-1124 | services-all

### DIFF
--- a/k8s/configMap-res.yaml
+++ b/k8s/configMap-res.yaml
@@ -22,14 +22,8 @@ data:
       Measurement: access_logs
       RetentionPolicy: default
     Rules:
-      - Id: alerting-tester
-        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/alerting-tester
-        SamplingRate: 1.0
-      - Id: whoami
-        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/whoami
-        SamplingRate: 1.0
-      - Id: geoip
-        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/geoip
+      - Id: services-all
+        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/
         SamplingRate: 1.0
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios

--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -22,14 +22,8 @@ data:
       Measurement: access_logs
       RetentionPolicy: default
     Rules:
-      - Id: alerting-tester
-        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/alerting-tester
-        SamplingRate: 1.0
-      - Id: whoami
-        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/whoami
-        SamplingRate: 1.0
-      - Id: geoip
-        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/geoip
+      - Id: services-all
+        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net
         SamplingRate: 1.0
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SER-1124

until we introduce `first-matching` way of assigning a bucket we need `service-all` rule back.