### PR TITLE
broader services-all

### DIFF
--- a/k8s/configMap-res.yaml
+++ b/k8s/configMap-res.yaml
@@ -23,7 +23,7 @@ data:
       RetentionPolicy: default
     Rules:
       - Id: services-all
-        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/
+        FrontendRegexp: ^.+\.k8s\.wikia\.net/
         SamplingRate: 1.0
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios

--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -23,7 +23,7 @@ data:
       RetentionPolicy: default
     Rules:
       - Id: services-all
-        FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net
+        FrontendRegexp: ^.+\.k8s\.wikia\.net
         SamplingRate: 1.0
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios


### PR DESCRIPTION
Due to bug in traefik (still waiting for 1.4) we have to broaden the scope of regex because some of the logs have different `frontend_name`.