### PR TITLE
correct regexp for services

### DIFF
--- a/k8s/configMap-poz_dev.yaml
+++ b/k8s/configMap-poz_dev.yaml
@@ -70,5 +70,5 @@ data:
         FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net/helios
         Sampling: 1.0
       - Id: services-all
-        FrontendRegexp: ^.+\.k8s\.wikia\.net
+        FrontendRegexp: ^services\.wikia-dev\.pl
         Sampling: 1.0

--- a/k8s/configMap-res.yaml
+++ b/k8s/configMap-res.yaml
@@ -70,5 +70,5 @@ data:
         FrontendRegexp: ^prod\.res\.k8s\.wikia\.net/helios
         Sampling: 1.0
       - Id: services-all
-        FrontendRegexp: ^.+\.k8s\.wikia\.net/
+        FrontendRegexp: ^services\.wikia\.com
         Sampling: 1.0

--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -76,6 +76,5 @@ data:
         FrontendRegexp: ^amp\.wikia\.com
         Sampling: 0.5
       - Id: services-all
-        FrontendRegexp: ^.+\.k8s\.wikia\.net
+        FrontendRegexp: ^services\.wikia\.com
         Sampling: 0.5
-

--- a/k8s/configMap-sjc_dev.yaml
+++ b/k8s/configMap-sjc_dev.yaml
@@ -70,5 +70,5 @@ data:
         FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net/helios
         Sampling: 1.0
       - Id: services-all
-        FrontendRegexp: ^.+\.k8s\.wikia\.net
+        FrontendRegexp: ^services\.wikia-dev\.us
         Sampling: 1.0


### PR DESCRIPTION
after traefik ugrade to 1.4 we stopped collecting metrics for external traffic.

I know that `services-all` doesn't look like a great name for external services traffic, but I don't want to change this config and tick scripts at the same time.