### PR TITLE
Updating rules

### DIFF
--- a/k8s/configMap-poz_dev.yaml
+++ b/k8s/configMap-poz_dev.yaml
@@ -57,17 +57,11 @@ data:
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
         Sampling: 0.5
-      - Id: helios-legacy
-        FrontendRegexp: ^services\.wikia\.com/auth
+      - Id: helios
+        FrontendRegexp: ^services\.wikia-dev\.pl/auth
         Sampling: 0.5
-      - Id: helios-dev-legacy
-        FrontendRegexp: ^services\.wikia-dev\.(pl|us)/auth
-        Sampling: 0.5
-      - Id: helios-dev-k8s
-        FrontendRegexp: ^services-k8s\.wikia-dev\.(pl|us)/helios
-        Sampling: 0.5
-      - Id: helios-dev-k8s
-        FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net/helios
+      - Id: helios
+        FrontendRegexp: ^services-k8s\.wikia-dev\.pl/helios
         Sampling: 0.5
       - Id: services-all
         FrontendRegexp: ^services\.wikia-dev\.pl

--- a/k8s/configMap-poz_dev.yaml
+++ b/k8s/configMap-poz_dev.yaml
@@ -54,7 +54,7 @@ data:
       - request__referer
       - request__user-agent
     Rules:
-      - Id: helios
+      - Id: helios-internal
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
         Sampling: 0.5
       - Id: helios
@@ -69,9 +69,9 @@ data:
       - Id: services-all
         FrontendRegexp: ^services-k8s\.wikia-dev\.pl
         Sampling: 0.5
-      - Id: services-all
+      - Id: services-all-internal
         FrontendRegexp: ^poz-dev\.k8s\.wikia\.net
         Sampling: 0.5
-      - Id: services-all
+      - Id: services-all-internal
         FrontendRegexp: ^dev\.poz-dev\.k8s\.wikia\.net
         Sampling: 0.5

--- a/k8s/configMap-poz_dev.yaml
+++ b/k8s/configMap-poz_dev.yaml
@@ -56,19 +56,28 @@ data:
     Rules:
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-legacy
         FrontendRegexp: ^services\.wikia\.com/auth
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-dev-legacy
         FrontendRegexp: ^services\.wikia-dev\.(pl|us)/auth
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-dev-k8s
         FrontendRegexp: ^services-k8s\.wikia-dev\.(pl|us)/helios
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-dev-k8s
         FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net/helios
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: services-all
         FrontendRegexp: ^services\.wikia-dev\.pl
-        Sampling: 1.0
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^services-k8s\.wikia-dev\.pl
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^poz-dev\.k8s\.wikia\.net
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^dev\.poz-dev\.k8s\.wikia\.net
+        Sampling: 0.5

--- a/k8s/configMap-res.yaml
+++ b/k8s/configMap-res.yaml
@@ -56,22 +56,31 @@ data:
     Rules:
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-legacy
         FrontendRegexp: ^services\.wikia\.com/auth
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-dev-legacy
         FrontendRegexp: ^services\.wikia-dev\.(pl|us)/auth
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-dev-k8s
         FrontendRegexp: ^services-k8s\.wikia-dev\.(pl|us)/helios
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-dev-k8s
         FrontendRegexp: ^prod\.res\.k8s\.wikia\.net/helios
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: services-all
         FrontendRegexp: ^services\.wikia\.com
-        Sampling: 1.0
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^services-k8s\.wikia\.com
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^res\.k8s\.wikia\.net
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^prod\.res\.k8s\.wikia\.net
+        Sampling: 0.5
       - Id: liftigniter-metadata
         FrontendRegexp: ^liftigniter-metadata\.prod\.res\.k8s\.wikia\.net
         Sampling: 0.05

--- a/k8s/configMap-res.yaml
+++ b/k8s/configMap-res.yaml
@@ -57,17 +57,8 @@ data:
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
         Sampling: 0.5
-      - Id: helios-legacy
+      - Id: helios
         FrontendRegexp: ^services\.wikia\.com/auth
-        Sampling: 0.5
-      - Id: helios-dev-legacy
-        FrontendRegexp: ^services\.wikia-dev\.(pl|us)/auth
-        Sampling: 0.5
-      - Id: helios-dev-k8s
-        FrontendRegexp: ^services-k8s\.wikia-dev\.(pl|us)/helios
-        Sampling: 0.5
-      - Id: helios-dev-k8s
-        FrontendRegexp: ^prod\.res\.k8s\.wikia\.net/helios
         Sampling: 0.5
       - Id: services-all
         FrontendRegexp: ^services\.wikia\.com

--- a/k8s/configMap-res.yaml
+++ b/k8s/configMap-res.yaml
@@ -54,7 +54,7 @@ data:
       - request__referer
       - request__user-agent
     Rules:
-      - Id: helios
+      - Id: helios-internal
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
         Sampling: 0.5
       - Id: helios
@@ -66,10 +66,10 @@ data:
       - Id: services-all
         FrontendRegexp: ^services-k8s\.wikia\.com
         Sampling: 0.5
-      - Id: services-all
+      - Id: services-all-internal
         FrontendRegexp: ^res\.k8s\.wikia\.net
         Sampling: 0.5
-      - Id: services-all
+      - Id: services-all-internal
         FrontendRegexp: ^prod\.res\.k8s\.wikia\.net
         Sampling: 0.5
       - Id: liftigniter-metadata

--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -54,7 +54,7 @@ data:
       - request__referer
       - request__user-agent
     Rules:
-      - Id: helios
+      - Id: helios-internal
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
         Sampling: 0.5
       - Id: helios
@@ -72,10 +72,10 @@ data:
       - Id: services-all
         FrontendRegexp: ^services-k8s\.wikia\.com
         Sampling: 0.5
-      - Id: services-all
+      - Id: services-all-internal
         FrontendRegexp: ^sjc\.k8s\.wikia\.net
         Sampling: 0.5
-      - Id: services-all
+      - Id: services-all-internal
         FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net
         Sampling: 0.5
       - Id: liftigniter-metadata

--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -57,17 +57,8 @@ data:
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
         Sampling: 0.5
-      - Id: helios-legacy
+      - Id: helios
         FrontendRegexp: ^services\.wikia\.com/auth
-        Sampling: 0.5
-      - Id: helios-dev-legacy
-        FrontendRegexp: ^services\.wikia-dev\.(pl|us)/auth
-        Sampling: 0.5
-      - Id: helios-dev-k8s
-        FrontendRegexp: ^services-k8s\.wikia-dev\.(pl|us)/helios
-        Sampling: 0.5
-      - Id: helios-dev-k8s
-        FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net/helios
         Sampling: 0.5
       - Id: amp-services
         FrontendRegexp: ^services\.wikia\.com/amp

--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -78,6 +78,15 @@ data:
       - Id: services-all
         FrontendRegexp: ^services\.wikia\.com
         Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^services-k8s\.wikia\.com
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^sjc\.k8s\.wikia\.net
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net
+        Sampling: 0.5
       - Id: liftigniter-metadata
         FrontendRegexp: ^liftigniter-metadata\.prod\.sjc\.k8s\.wikia\.net
         Sampling: 0.05

--- a/k8s/configMap-sjc_dev.yaml
+++ b/k8s/configMap-sjc_dev.yaml
@@ -56,19 +56,28 @@ data:
     Rules:
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-legacy
         FrontendRegexp: ^services\.wikia\.com/auth
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-dev-legacy
         FrontendRegexp: ^services\.wikia-dev\.(pl|us)/auth
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-dev-k8s
         FrontendRegexp: ^services-k8s\.wikia-dev\.(pl|us)/helios
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: helios-dev-k8s
         FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net/helios
-        Sampling: 1.0
+        Sampling: 0.5
       - Id: services-all
         FrontendRegexp: ^services\.wikia-dev\.us
-        Sampling: 1.0
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^services-k8s\.wikia-dev\.us
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^sjc-dev\.k8s\.wikia\.net
+        Sampling: 0.5
+      - Id: services-all
+        FrontendRegexp: ^dev\.sjc-dev\.k8s\.wikia\.net
+        Sampling: 0.5

--- a/k8s/configMap-sjc_dev.yaml
+++ b/k8s/configMap-sjc_dev.yaml
@@ -57,17 +57,11 @@ data:
       - Id: helios
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
         Sampling: 0.5
-      - Id: helios-legacy
-        FrontendRegexp: ^services\.wikia\.com/auth
+      - Id: helios
+        FrontendRegexp: ^services\.wikia-dev\.us/auth
         Sampling: 0.5
-      - Id: helios-dev-legacy
-        FrontendRegexp: ^services\.wikia-dev\.(pl|us)/auth
-        Sampling: 0.5
-      - Id: helios-dev-k8s
-        FrontendRegexp: ^services-k8s\.wikia-dev\.(pl|us)/helios
-        Sampling: 0.5
-      - Id: helios-dev-k8s
-        FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net/helios
+      - Id: helios
+        FrontendRegexp: ^services-k8s\.wikia-dev\.us/helios
         Sampling: 0.5
       - Id: services-all
         FrontendRegexp: ^services\.wikia-dev\.us

--- a/k8s/configMap-sjc_dev.yaml
+++ b/k8s/configMap-sjc_dev.yaml
@@ -54,7 +54,7 @@ data:
       - request__referer
       - request__user-agent
     Rules:
-      - Id: helios
+      - Id: helios-internal
         FrontendRegexp: ^[^\.]+\.k8s\.wikia\.net/helios
         Sampling: 0.5
       - Id: helios
@@ -69,9 +69,9 @@ data:
       - Id: services-all
         FrontendRegexp: ^services-k8s\.wikia-dev\.us
         Sampling: 0.5
-      - Id: services-all
+      - Id: services-all-internal
         FrontendRegexp: ^sjc-dev\.k8s\.wikia\.net
         Sampling: 0.5
-      - Id: services-all
+      - Id: services-all-internal
         FrontendRegexp: ^dev\.sjc-dev\.k8s\.wikia\.net
         Sampling: 0.5


### PR DESCRIPTION
This should add 'internal' traffic to our metrics and cleanup the naming of rules. I've also updated some Helios rules to match actual configuration.

ping: @Wikia/core-platform-team @Wikia/services-team 