### PR TITLE
PLATFORM-3329: updating sampling rate

### DIFF
--- a/k8s/configMap-res.yaml
+++ b/k8s/configMap-res.yaml
@@ -56,19 +56,19 @@ data:
     Rules:
       - Id: helios
         FrontendRegexp: ^prod\.res\.k8s\.wikia\.net/helios
-        Sampling: 0.5
+        Sampling: 0.1
       - Id: helios
         FrontendRegexp: ^services\.wikia\.com/auth
-        Sampling: 0.5
+        Sampling: 0.1
       - Id: services-all
         FrontendRegexp: ^services\.wikia\.com
-        Sampling: 0.5
+        Sampling: 0.2
       - Id: services-all-internal
         FrontendRegexp: ^res\.k8s\.wikia\.net
-        Sampling: 0.5
+        Sampling: 0.1
       - Id: services-all-internal
         FrontendRegexp: ^prod\.res\.k8s\.wikia\.net
-        Sampling: 0.5
+        Sampling: 0.1
       - Id: liftigniter-metadata
         FrontendRegexp: ^liftigniter-metadata\.prod\.res\.k8s\.wikia\.net
         Sampling: 0.05

--- a/k8s/configMap-sjc.yaml
+++ b/k8s/configMap-sjc.yaml
@@ -56,10 +56,10 @@ data:
     Rules:
       - Id: helios
         FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net/helios
-        Sampling: 0.5
+        Sampling: 0.1
       - Id: helios
         FrontendRegexp: ^services\.wikia\.com/auth
-        Sampling: 0.5
+        Sampling: 0.1
       - Id: amp-services
         FrontendRegexp: ^services\.wikia\.com/amp
         Sampling: 0.5
@@ -68,13 +68,13 @@ data:
         Sampling: 0.5
       - Id: services-all
         FrontendRegexp: ^services\.wikia\.com
-        Sampling: 0.5
+        Sampling: 0.2
       - Id: services-all-internal
         FrontendRegexp: ^sjc\.k8s\.wikia\.net
-        Sampling: 0.5
+        Sampling: 0.1
       - Id: services-all-internal
         FrontendRegexp: ^prod\.sjc\.k8s\.wikia\.net
-        Sampling: 0.5
+        Sampling: 0.1
       - Id: liftigniter-metadata
         FrontendRegexp: ^liftigniter-metadata\.prod\.sjc\.k8s\.wikia\.net
         Sampling: 0.05


### PR DESCRIPTION
I checked the number of points in the last 15 minutes per rule id:
```
      - Id: helios - 167048
      - Id: amp-services 8
      - Id: amp 0
      - Id: services-all - 31102
      - Id: services-all-internal - 929283
      - Id: liftigniter-metadata - 0
      - Id: mobile-wiki - 5629
      - Id: discussions-front-end - 534
```
Based on it, I'm decreasing sampling rate for `helios`, `services-al`l and `services-all-internal` in both datacenters